### PR TITLE
test: verify /status prompt lacks variables and tools

### DIFF
--- a/tests/unit/prompts.test.ts
+++ b/tests/unit/prompts.test.ts
@@ -49,5 +49,7 @@ describe('MCP Prompts - Orchestrator definitions', () => {
     const built = await registry.build('/status', {});
     expect(built.name).toBe('/status');
     expect(built.messages.length).toBeGreaterThan(0);
+    expect(built.variables).toEqual({});
+    expect(built.suggestedTools ?? []).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary
- ensure /status prompt build returns empty variables
- check /status prompt suggests no tools

## Testing
- `npm run test:unit` *(fails: Cannot find package '@core/errors' ...)*

------
https://chatgpt.com/codex/tasks/task_e_68a294ce2c0c8327b6cbeac39a7a2f94