### PR TITLE
docs: standardize config filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ ENABLE_METRICS=true
 
 ### Configuration File
 
-Create `orchestrator.config.json`:
+Create `mcp-orchestrator.config.json`:
 
 ```json
 {

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -117,7 +117,7 @@ AUTO_CLEANUP=true                  # Auto cleanup old files
 
 ### Main Configuration File
 
-Create `orchestrator.config.json` in your project root:
+Create `mcp-orchestrator.config.json` in your project root:
 
 ```json
 {
@@ -242,7 +242,7 @@ Create `orchestrator.config.json` in your project root:
 
 ### YAML Configuration Alternative
 
-You can also use YAML format (`orchestrator.config.yaml`):
+You can also use YAML format (`mcp-orchestrator.config.yaml`):
 
 ```yaml
 version: "1.0.0"
@@ -972,7 +972,7 @@ mcp-orchestrator config test
 
 ```bash
 # Check file location
-ls -la orchestrator.config.{json,yaml,yml}
+ls -la mcp-orchestrator.config.{json,yaml,yml}
 
 # Verify syntax
 mcp-orchestrator config validate --file ./config.json
@@ -1049,7 +1049,7 @@ const newConfig = {
   }, {})
 };
 
-fs.writeFileSync('./orchestrator.config.json', JSON.stringify(newConfig, null, 2));
+fs.writeFileSync('./mcp-orchestrator.config.json', JSON.stringify(newConfig, null, 2));
 ```
 
 ---

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -263,7 +263,7 @@ Navigate using arrow keys:
 
 ### Using Configuration Files
 
-Create `orchestrator.yaml`:
+Create `mcp-orchestrator.config.yaml`:
 
 ```yaml
 project:
@@ -309,7 +309,7 @@ agents:
 Run with config:
 
 ```bash
-mcp-orchestrator run --config orchestrator.yaml
+mcp-orchestrator run --config mcp-orchestrator.config.yaml
 ```
 
 ## CLI Commands

--- a/src/cli/utils/config.ts
+++ b/src/cli/utils/config.ts
@@ -86,7 +86,8 @@ const ConfigSchema = z.object({
 export type Config = z.infer<typeof ConfigSchema>;
 
 /**
- * Configuration file paths in order of priority (lowest to highest)
+ * Configuration file paths in order of priority (lowest to highest).
+ * The official configuration filename is `mcp-orchestrator.config.json`.
  */
 const CONFIG_FILES = [
   'mcp-orchestrator.config.json',


### PR DESCRIPTION
## Summary
- standardize official config filename to `mcp-orchestrator.config.json`
- document `mcp-orchestrator.config.yaml` alternative
- clarify config utility about official config file

## Testing
- `npm install`
- `npm test` *(fails: Cannot find package '@core/errors', Playwright test describe misuse, MessageType not defined, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a294c69d508327a90a13a7302dc8bd