### PR TITLE
fix: import MessageType runtime

### DIFF
--- a/src/roles/base-agent.ts
+++ b/src/roles/base-agent.ts
@@ -12,19 +12,19 @@ import {
   TimeoutError,
   ValidationError
 } from '../core/errors';
-import type { 
-  AgentCapability, 
-  AgentContext, 
+import type {
+  AgentCapability,
+  AgentContext,
   AgentEvent,
   AgentInfo,
-  AgentMessage, 
+  AgentMessage,
   AgentMetrics,
   AgentResult,
   AgentType,
   EventHandler,
-  MessageType,
   Metrics
 } from '../types';
+import { MessageType } from '../types';
 import { createLogger } from '../utils/logger';
 
 /**


### PR DESCRIPTION
## Summary
- import MessageType as runtime value in BaseAgent to avoid ReferenceError

## Testing
- `npx vitest tests/unit/roles/architect.test.ts` *(fails: initialization and execution assertions)*
- `npm test` *(fails: module resolution and assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a28fd1256c832784a008af155d4b4f